### PR TITLE
ビュー修正、rubocop済

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -6,5 +6,5 @@ class Postage < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  belongs_to :items
+  has_many :items
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -18,5 +18,5 @@ class Prefecture < ActiveHash::Base
     { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
   include ActiveHash::Associations
-  belongs_to :items
+  has_many :items
 end

--- a/app/models/shipping_date.rb
+++ b/app/models/shipping_date.rb
@@ -7,5 +7,5 @@ class ShippingDate < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  belongs_to :items
+  has_many :items
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -10,5 +10,5 @@ class Status < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  belongs_to :items
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,57 +127,53 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+              <%# 商品が売れていればsold outを表示しましょう(購入機能実装時に修正) %> 
+              <%# <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div> %>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.product %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.postage.name %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+      <% if @items.length == 0 %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -70,19 +70,19 @@ RSpec.describe Item, type: :model do
       it '価格は半角英数混合だと出品できない' do
         @item.price = '1a2b3c'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '価格は半角英語だと出品できない' do
         @item.price = 'aabbcc'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '価格は全角文字だと出品できない' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '価格が300未満だと出品できない' do
@@ -92,7 +92,7 @@ RSpec.describe Item, type: :model do
       end
 
       it '価格が10000000以上だと出品できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than 10000000')
       end
@@ -100,7 +100,7 @@ RSpec.describe Item, type: :model do
       it 'ユーザー情報が紐づいていない場合は出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
     end
   end


### PR DESCRIPTION
# What
商品一覧表示機能実装

# Why
ユーザーが出品した商品をトップページに表示できるようにするため


【商品のデータがない場合は、ダミー商品が表示されている動画】
https://gyazo.com/1aca26dd15abe66dcf1ff1e561239b4a

【商品のデータがある場合は、商品が一覧で表示されている動画】
https://gyazo.com/cb60983cdfcfc8446a7e1a15904ed2ab

【変更内容】
indexファイルに商品を一覧表示できるよう記述、何もなければダミー表示
itemsコントローラーindexアクション記述
ActiveHashファイルアソシエーション記述ミス修正